### PR TITLE
Add conda install link to get_tidy section.

### DIFF
--- a/homepage/_posts/1970-06-01-get_tidy.md
+++ b/homepage/_posts/1970-06-01-get_tidy.md
@@ -32,6 +32,7 @@ in adopting [**CMake**][11]. **Tidy**’s source code is available on its
 - [Fink][21]: `fink install tidy`
 - [Homebrew][20]: `brew install tidy-html5`
 - [MacPorts][22]: `sudo port install tidy`
+- [Conda][31]: `conda install -c conda-forge tidy-html5`
 
 
 ### Windows
@@ -41,6 +42,7 @@ Coming soon!
 ### Linux
 
 - [Debian][30]: `sudo apt install tidy`
+- [Conda][31]: `conda install -c conda-forge tidy-html5`
 
 
 [1]: https://github.com/htacg/tidy-html5
@@ -56,3 +58,4 @@ Coming soon!
 [22]: https://www.macports.org/
 
 [30]: http://www.debian.org/
+[31]: https://conda.io


### PR DESCRIPTION
I've recently added tidy-html to conda-forge under https://github.com/conda-forge/tidy-html5-feedstock. It is currently building both stable (5.6) and pre-release (5.7+) versions for linux and osx.